### PR TITLE
Add online English conversation plan link to learning tools section

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,6 +264,28 @@
     }
     /* ▲▲▲ ここまで ▲▲▲ */
 
+    /* ▼▼▼ オンライン英会話プランリンクのスタイル ▼▼▼ */
+    .online-english-link {
+      color: #ff8e48;
+      font-size: 18px;
+      font-weight: bold;
+      text-decoration: none;
+      display: inline-block;
+      padding: 12px 24px;
+      border: 2px solid #ff8e48;
+      border-radius: 5px;
+      transition: all 0.3s ease;
+      margin-top: 2rem;
+    }
+    
+    .online-english-link:hover {
+      background-color: #ff8e48;
+      color: #FFFFFF;
+      transform: translateY(-2px);
+      box-shadow: 0 4px 8px rgba(255, 142, 72, 0.3);
+    }
+    /* ▲▲▲ ここまで ▲▲▲ */
+
   </style>
 </head>
 <header class="section">
@@ -342,6 +364,11 @@
         <p class="paragraph_small margin-bottom_small">数多くの企業研修を担当してきた講師による、様々なセミナーをオンデマンド配信しています。</p>
         <a href="https://user.alc-unlimited.com/services/seminar-movie/" target="_blank" rel="noopener noreferrer" class="button on-inverse w-button">視聴</a>
       </div>
+      </div>
+      <div class="text-align_center">
+        <a href="https://eikaiwa-student.alc.co.jp/jp/user/enterprise_student_login" target="_blank" rel="noopener noreferrer" class="online-english-link">
+          ＋オンライン英会話プランの方
+        </a>
       </div>
   </div>
 </section>


### PR DESCRIPTION
## 概要
「学習ツール」セクションの最下部に「＋オンライン英会話プランの方」のリンクを追加しました。

## 変更内容
### index.html
- 学習ツールセクションの最後に新しいリンクを追加
- リンク先: https://eikaiwa-student.alc.co.jp/jp/user/enterprise_student_login
- カスタムCSSクラス (online-english-link) を追加して、サイトデザインと統一感のあるスタイリングを実装

### スタイル追加
- プライマリーカラー (#ff8e48) を使用した枠線付きボタンスタイル
- ホバー時の背景色変更とアニメーション効果
- 他のボタンとの視覚的な一貫性を保持

## 動作確認
- [x] リンクをクリックすると新しいタブでオンライン英会話ログインページが開くことを確認
- [x] ホバー効果が正しく動作することを確認
- [x] レスポンシブデザインでの表示を確認

## その他
外部リンクのため、セキュリティを考慮して `target='_blank'` と `rel='noopener noreferrer'` 属性を設定しています。