### PR TITLE
refactor: Clean up user guide page and enable PDF display by default

### DIFF
--- a/user-guide.html
+++ b/user-guide.html
@@ -183,80 +183,9 @@
       height: 20px;
     }
 
-    /* ガイド説明セクション */
-    .guide-description {
-      background-color: #fff9e6;
-      border-left: 4px solid #ff8e48;
-      padding: 25px;
-      border-radius: 6px;
-      margin-bottom: 30px;
-    }
 
-    .guide-description h3 {
-      color: #000000;
-      font-size: 1.2em;
-      margin-bottom: 15px;
-      font-weight: 600;
-      font-family: Verdana, Geneva, sans-serif;
-    }
 
-    .guide-description p {
-      color: #333333;
-      line-height: 1.8;
-      margin-bottom: 10px;
-    }
 
-    .guide-description ul {
-      color: #333333;
-      line-height: 1.8;
-      margin: 10px 0;
-      padding-left: 20px;
-    }
-
-    /* コンテンツハイライト */
-    .content-highlights {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-      gap: 20px;
-      margin-bottom: 30px;
-    }
-
-    .highlight-card {
-      background-color: #ffffff;
-      border-radius: 8px;
-      padding: 20px;
-      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
-      border: 1px solid #f0f0f0;
-    }
-
-    .highlight-card h4 {
-      color: #000000;
-      font-size: 1.1em;
-      margin-bottom: 10px;
-      font-weight: 600;
-      font-family: Verdana, Geneva, sans-serif;
-    }
-
-    .highlight-card p {
-      color: #333333;
-      line-height: 1.6;
-      font-size: 0.95em;
-      margin: 0;
-    }
-
-    .highlight-number {
-      background-color: #ff8e48;
-      color: #ffffff;
-      width: 30px;
-      height: 30px;
-      border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-weight: bold;
-      margin-bottom: 10px;
-      font-size: 0.9em;
-    }
 
     /* レスポンシブデザイン */
     @media (max-width: 768px) {
@@ -289,9 +218,7 @@
         height: 500px;
       }
 
-      .content-highlights {
-        grid-template-columns: 1fr;
-      }
+
     }
 
     @media (max-width: 480px) {
@@ -322,42 +249,7 @@
       トップページに戻る
     </a>
 
-    <!-- ガイド説明セクション -->
-    <div class="guide-description">
-      <h3>📖 ユーザーガイドについて</h3>
-      <p>このガイドでは、ALC Study Unlimitedのすべての機能と学習ツールの使い方を詳しく説明しています。</p>
-      <ul>
-        <li>学習ツールの基本的な使い方</li>
-        <li>効果的な学習方法とスケジューリング</li>
-        <li>各サービスの詳細な操作手順</li>
-        <li>よくあるご質問と回答</li>
-        <li>お問い合わせ方法</li>
-      </ul>
-    </div>
 
-    <!-- コンテンツハイライト -->
-    <div class="content-highlights">
-      <div class="highlight-card">
-        <div class="highlight-number">1</div>
-        <h4>サービス概要</h4>
-        <p>ALC Study Unlimitedとは何か、どのような学習ツールが利用できるかを詳しく説明します。</p>
-      </div>
-      <div class="highlight-card">
-        <div class="highlight-number">2</div>
-        <h4>利用の流れ</h4>
-        <p>初回登録からログイン、各サービスの利用開始までの手順を分かりやすく解説します。</p>
-      </div>
-      <div class="highlight-card">
-        <div class="highlight-number">3</div>
-        <h4>学習ツール詳細</h4>
-        <p>booco、TALKING MARATHON、オンライン英会話など、各ツールの使い方を詳しく説明します。</p>
-      </div>
-      <div class="highlight-card">
-        <div class="highlight-number">4</div>
-        <h4>サポート情報</h4>
-        <p>お困りの際のお問い合わせ方法や、よくあるご質問への回答をご案内します。</p>
-      </div>
-    </div>
 
     <!-- PDFビューアセクション -->
     <div class="pdf-viewer-section">
@@ -376,12 +268,12 @@
             <svg fill="currentColor" viewBox="0 0 20 20">
               <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd"></path>
             </svg>
-            <span id="viewer-toggle-text">PDFを表示</span>
+            <span id="viewer-toggle-text">PDFを非表示</span>
           </button>
         </div>
       </div>
       
-      <div class="pdf-viewer" id="pdf-viewer" style="display: none;">
+      <div class="pdf-viewer" id="pdf-viewer">
         <div class="pdf-loading" id="pdf-loading">
           PDFを読み込んでいます...
         </div>
@@ -391,7 +283,7 @@
   </div>
 
   <script>
-    let pdfViewerVisible = false;
+    let pdfViewerVisible = true;
     
     function togglePdfViewer() {
       const viewer = document.getElementById('pdf-viewer');
@@ -431,10 +323,23 @@
       }
     }
 
-    // ページ読み込み時にPDFビューアを初期化
+    // ページ読み込み時にPDFを初期化
     document.addEventListener('DOMContentLoaded', function() {
-      // 初期状態では非表示
-      document.getElementById('pdf-viewer').style.display = 'none';
+      // 初期状態でPDFを表示
+      const iframe = document.getElementById('pdf-iframe');
+      const loading = document.getElementById('pdf-loading');
+      const pdfUrl = 'https://page.gensparksite.com/get_upload_url/c62d496d942bb86b58ac1e84af9e8169c64817e44964b89656f0d863e3170e0b/default/d42fbbe9-3d5c-45c5-a7f5-2dd8584f4e8a';
+      
+      iframe.src = pdfUrl;
+      
+      iframe.onload = function() {
+        loading.style.display = 'none';
+        iframe.style.display = 'block';
+      };
+      
+      iframe.onerror = function() {
+        loading.innerHTML = 'PDFの読み込みに失敗しました。<br><a href="' + pdfUrl + '" target="_blank" style="color: #ff8e48;">こちらから直接PDFを開いてください</a>';
+      };
     });
   </script>
 </body>


### PR DESCRIPTION
- Remove guide description section with bullet points
- Remove content highlights cards section
- Make PDF viewer display by default on page load
- Update toggle button text to reflect default state
- Clean up unused CSS styles for removed sections